### PR TITLE
feat: add slate 2023 paper

### DIFF
--- a/_data/references.bib
+++ b/_data/references.bib
@@ -96,6 +96,16 @@
   doi={10.1109/ICASSP48485.2024.10446224}
   }
 
+@inproceedings{freisinger2023unsupervised,
+  author={Steffen Freisinger and Fabian Schneider and Aaricia Herygers and Munir Georges and Tobias Bocklet and Korbinian Riedhammer},
+  title={{Unsupervised Multilingual Topic Segmentation of Video Lectures: What can Hierarchical Labels tell us about the Performance?}},
+  year={2023},
+  booktitle={Proc. 9th Workshop on Speech and Language Technology in Education (SLaTE)},
+  pages={141--145},
+  doi={10.21437/SLaTE.2023-27},
+  issn={2311-4975}
+}
+
 @article{bocklet2023ki,
   doi = {10.1055/a-2089-5778},
   journal = {Sprache, Stimme, Gehör},


### PR DESCRIPTION
Adding [paper published in SLaTE 2023 proceedings](https://www.isca-archive.org/slate_2023/freisinger23_slate.html)