### PR TITLE
Add missing staff profile pictures and restore alphabetical order

### DIFF
--- a/_data/staff_scientific.yml
+++ b/_data/staff_scientific.yml
@@ -83,6 +83,13 @@
     - ttz
   email: steffen.freisinger@th-nuernberg.de
 
+- name: Robert Goldbrich
+  alias: goldbrichro
+  photo: bio-photo.jpg
+  info: Research Scientist
+  subject: speech processing
+  email: robert.goldbrich@th-nuernberg.de
+
 - name: Kashaf Gulzar
   alias: gulzarka
   photo: bio-photo-gulzar.jpg
@@ -92,6 +99,13 @@
     - dementia
     - enom
   email: kashaf.gulzar@th-nuernberg.de
+
+- name: Mareike Müller
+  alias: muellerma
+  photo: bio-photo.jpg
+  info: Research Scientist
+  subject: automation of psychometric tests
+  email: mareike.mueller@th-nuernberg.de
 
 - name: Thomas Ranzenberger
   alias: ranzenbergerth
@@ -151,13 +165,6 @@
     - kia
   email: philipp.steigerwald@th-nuernberg.de
 
-- name: Robert Goldbrich
-  alias: goldbrichro
-  photo: bio-photo.jpg
-  info: Research Scientist
-  subject: speech processing
-  email: robert.goldbrich@th-nuernberg.de
-
 - name: Yannes Tallowitz
   alias: tallowitzya
   photo: bio-photo.jpg
@@ -165,14 +172,9 @@
   subject: secure and private computation
   email: yannes.tallowitz@th-nuernberg.de
 
-- name: Mareike Müller
-  alias: muellerma
-  info: Research Scientist
-  subject: automation of psychometric tests
-  email: mareike.mueller@th-nuernberg.de
-
 - name: Christopher Witzl
   alias: witzlch
+  photo: bio-photo.jpg
   info: Research Scientist
   subject: automatic speech recognition
   email: christopher.witzl@th-nuernberg.de


### PR DESCRIPTION
The team page is missing the default profile picture for Mueller and Witzl. The list of team members is also only somewhat alphabetically sorted.
This adds the missing profile pictures and restores alphabetical order.

**Question:** Should we add the remaining Speeches staff?
I also noticed that links to the projects `kia`, `hans`, `ttz`, and `fitness` on staff profiles are dead. 