### PR TITLE
Add ACL bibtex entries

### DIFF
--- a/_data/references.bib
+++ b/_data/references.bib
@@ -63,6 +63,17 @@
 
 @string{wocci = {Proc.\ ISCA Workshop on Child, Computer and Interaction (WOCCI)}}
 
+@inproceedings{seeberger2026evaluation,
+  author={Seeberger, Philipp and Freisinger, Steffen and Bocklet, Tobias and Riedhammer, Korbinian},
+  booktitle=acl, 
+  title={Evaluation Pitfalls and Challenges in Multimedia Event Extraction}, 
+  year={2026},
+  volume={},
+  number={},
+  pages={30885--30900},
+  url={https://aclanthology.org/2026.acl-long.1426/}
+}
+
 @inproceedings{braun2026mitigating,
     title={Mitigating Scoring Errors and Compensating for Nonverbal Subtests in Speech-Based Dementia Assessment}, 
     author={Braun, Franziska and Witzl, Christopher and Erzigkeit, Andreas and Lehfeld, Hartmut and Hillemacher, Thomas and Bocklet, Tobias and Riedhammer, Korbinian},
@@ -144,6 +155,18 @@
   number={},
   pages={1-5},
   doi={10.1109/ICASSP49660.2025.10889566}
+}
+
+@inproceedings{seeberger2025generalizing,
+  author={Seeberger, Philipp and Freisinger, Steffen and Bocklet, Tobias and Riedhammer, Korbinian},
+  booktitle={Proc.\ Int'l Joint Conference on Natural Language Processing and the Asia-Pacific Chapter of the Association for Computational Linguistics (IJCNLP-AACL)}, 
+  title={Generalizing to Unseen Disaster Events: A Causal View}, 
+  year={2025},
+  volume={},
+  number={},
+  pages={28--37},
+  doi={10.18653/v1/2025.findings-ijcnlp.2},
+  url={https://aclanthology.org/2025.findings-ijcnlp.2/}
 }
 
 @inproceedings{simic2025temporal,


### PR DESCRIPTION
Added to references.bib:
- ACL 2026: Evaluation Pitfalls and Challenges in Multimedia Event Extraction
- IJCNLP-AACL 2025: Generalizing to Unseen Disaster Events: A Causal View